### PR TITLE
Init from serial number or existing (NewScale)Serial connection

### DIFF
--- a/examples/back_and_forth_3d.py
+++ b/examples/back_and_forth_3d.py
@@ -8,17 +8,18 @@ NewScaleSerial and moving it back and forth along all 3 axes.
 import sys
 
 from newscale.multistage import USBXYZStage
-from newscale.interfaces import NewScaleSerial, USBInterface
+from newscale.interfaces import USBInterface
+from newscale.new_scale_serial import NewScaleSerial, get_instances
 
 MIN_TRAVEL_UM = 0
 MAX_TRAVEL_UM = 15000
 
 # Create USBXYZStage
-instances = NewScaleSerial.get_instances()
+instances = list(get_instances().values())
 if len(instances) == 0:
     sys.exit(1)
-serialInstance = instances[0]
-stage = USBXYZStage(usb_interface=USBInterface(serialInstance))
+usb_interface = USBInterface(serial=instances[0])
+stage = USBXYZStage(usb_interface=usb_interface)
 
 # X-axis
 stage.move_absolute(x=1000)

--- a/examples/list_serial_devices.py
+++ b/examples/list_serial_devices.py
@@ -4,4 +4,4 @@ from newscale.new_scale_serial import get_instances
 
 instances = get_instances()
 for k, v in instances.items():
-    print(f"Serial # {k}, on {type(v)} interface.")
+    print(f"Serial #{k} connected on {v.port}")

--- a/examples/list_serial_devices.py
+++ b/examples/list_serial_devices.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from newscale.interfaces import NewScaleSerial
+from newscale.new_scale_serial import get_instances
 
-instances = NewScaleSerial.get_instances()
-for i in instances:
-    print('Serial # %s, on %s' % (i.get_serial_number(), i.get_port_name()))
+instances = get_instances()
+for k, v in instances.items():
+    print(f"Serial # {k}, on {type(v)} interface.")

--- a/examples/multistage_test.py
+++ b/examples/multistage_test.py
@@ -7,7 +7,8 @@ import sys
 
 from newscale.device_codes import Direction
 from newscale.multistage import USBXYZStage, PoEXYZStage
-from newscale.interfaces import NewScaleSerial, USBInterface
+from newscale.interfaces import USBInterface
+from newscale.new_scale_serial import NewScaleSerial, get_instances
 
 # Uncomment for some prolific log statements.
 #import logging
@@ -21,11 +22,11 @@ MIN_TRAVEL_UM = 0
 MAX_TRAVEL_UM = 15000
 
 # Create USBXYZStage
-instances = NewScaleSerial.get_instances()
+instances = list(get_instances().values())
 if len(instances) == 0:
     sys.exit(1)
 serialInstance = instances[0]
-stage = USBXYZStage(usb_interface=USBInterface(serialInstance))
+stage = USBXYZStage(usb_interface=USBInterface(serial=serialInstance))
 
 # Create PoEXYZStage
 #ip_address = "10.128.49.57"

--- a/examples/read_firmware.py
+++ b/examples/read_firmware.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import pprint
+import sys
 
-from newscale.interfaces import NewScaleSerial, USBInterface
+from newscale.interfaces import USBInterface
+from newscale.new_scale_serial import NewScaleSerial, get_instances
 from newscale.stage import M3LinearSmartStage
 
 # Uncomment for some prolific log statements.
@@ -14,12 +16,11 @@ from newscale.stage import M3LinearSmartStage
 #    logging.Formatter(fmt='%(asctime)s:%(name)s:%(levelname)s: %(message)s'))
 
 # Connect to a single stage.
-instances = NewScaleSerial.get_instances()
+instances = list(get_instances().values())
 if len(instances) == 0:
     sys.exit(1)
-else:
-    serialInstance = instances[0]
-stage = M3LinearSmartStage(USBInterface(serialInstance), "01")
+serialInstance = instances[0]
+stage = M3LinearSmartStage(USBInterface(serial=serialInstance), "01")
 
 # Print firmware version, closed loop state, position, and motor status
 print(f"Firmware is {stage.get_firmware_version()}.")

--- a/src/newscale/interfaces.py
+++ b/src/newscale/interfaces.py
@@ -73,11 +73,20 @@ class USBInterface(HardwareInterface):
 
         .. code-block:: python
 
-            # FIXME: test this.
-            interface = USBInterface("M3-USB-0")  # OR
+            # Create a connection from a known USB Interface serial number
+            interface = USBInterface(serial_number="46120")  # OR
 
-            serial = list(get_instances().values())[0]
-            interface = USBInterface(serial)
+            # Find all hubs and create a connection on the first one.
+            from newscale.new_scale_serial import get_instances()
+
+            ser = list(get_instances().values())[0]
+            interface = USBInterface(serial=ser)  # OR
+
+            # Create a connection manually by passing in a Serial instance.
+            from serial import Serial
+
+            ser = Serial("COM3", baudrate=250000)
+            interface = USBInterface(serial=ser)
 
         """
         if all(param is None for param in [serial_number, serial]):

--- a/src/newscale/new_scale_serial.py
+++ b/src/newscale/new_scale_serial.py
@@ -1,0 +1,138 @@
+"""Utilities for accessing New Scale devices implemented as usbxpress devices."""
+
+try:  # cache appeared in 3.9
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
+from serial import Serial
+from serial.tools.list_ports import comports as list_comports
+from sys import platform as PLATFORM
+if PLATFORM == 'win32':
+    from newscale.usbxpress import USBXpressLib, USBXpressDevice
+
+VID_NEWSCALE = 0x10c4
+PID_NEWSCALE_COMPORT = 0xea60
+PID_NEWSCALE_USBX = 0xea61
+
+
+@cache
+def get_instances():
+    """Factory function to get all New Scale USB Serial hubs, regardless
+    of VID/PID. These will be returned in a dict, keyed by serial number, where
+    the values are either Pyserial or NewScaleSerial objects.
+
+    Usage:
+        instances = NewScaleSerial.get_instances()
+        -> [newScaleSerial1, newScaleSerial2]
+        for instance in instances:
+            print('serial number = ', instance.get_serial_number())
+    """
+    instances = {}
+    if PLATFORM == 'linux':
+        for comport in list_comports():
+            if comport.vid == VID_NEWSCALE:
+                if comport.pid in [PID_NEWSCALE_COMPORT, PID_NEWSCALE_USBX]:
+                    hwid = comport.hwid
+                    serial_number = hwid.split()[2].split('=')[1]
+                    instances[serial_number] = (NewScaleSerial(serial_number,
+                                                pyserial_device=Serial(comport.device)))
+    elif PLATFORM == 'win32':
+        n = USBXpressLib().get_num_devices()
+        for i in range(n):
+            device = USBXpressDevice(i)
+            if int(device.get_vid(), 16) == VID_NEWSCALE:
+                if int(device.get_pid(), 16) == PID_NEWSCALE_USBX:
+                    serial_number = device.get_serial_number()
+                    instances[serial_number] = (NewScaleSerial(serial_number,
+                                                usbxpress_device=device))
+        for comport in list_comports():
+            if comport.vid == VID_NEWSCALE:
+                if comport.pid == PID_NEWSCALE_COMPORT:
+                    hwid = comport.hwid
+                    serial_number = hwid.split()[2].split('=')[1]
+                    instances[serial_number] = (NewScaleSerial(serial_number,
+                                                pyserial_device=Serial(comport.device)))
+    return instances
+
+
+class NewScaleSerial:
+    """Wrapper for NewScale USB hubs with a pyserial-like interface."""
+
+    # FIXME: technically, we don't need to the serial number to create this
+    #   wrapper. Maybe we can infer it inside this class?
+    def __init__(self, serial_number, pyserial_device=None, usbxpress_device=None):
+        self.sn = serial_number
+        if pyserial_device:
+            self.t = 'pyserial'
+            self.io = pyserial_device
+        elif usbxpress_device:
+            self.t = 'usbxpress'
+            usbxpress_device.open()
+            self.io = usbxpress_device
+        self.set_timeout(1)
+        self.set_baudrate(250000)
+
+    @property
+    def port(self):
+        """Return a unique identifier for the device connection."""
+        if self.t == 'pyserial':
+            return self.io.port
+        elif self.t == 'usbxpress':
+            return self.get_serial_number()
+
+    def get_serial_number(self):
+        return self.sn
+
+    # Mimic pyserial interface for getting/setting baudrate
+    @property
+    def baudrate(self):
+        return self.io.baudrate
+
+    @baudrate.setter
+    def baudrate(self, baudrate: int):
+        if self.t == 'pyserial':
+            self.io.baudrate = baudrate
+        elif self.t == 'usbxpress':
+            self.io.set_baud_rate(baudrate)
+
+    def set_baudrate(self, baudrate: int):
+        self.baudrate = baudrate
+
+    @property
+    def timeout(self):
+        return self.io.get_timeouts()[0]  # both timeouts are the same.
+
+    @timeout.setter
+    def timeout(self, seconds: float):
+        if self.t == 'pyserial':
+            self.io.timeout = seconds
+        elif self.t == 'usbxpress':
+            timeout_ms = round(seconds * 1000)
+            self.io.set_timeouts(timeout_ms, timeout_ms)
+
+    def set_timeout(self, timeout_s: float):
+        self.timeout = timeout_s
+
+    def write(self, data: bytes):
+        self.io.write(data)
+
+    def read_until(self, expected: bytes = b'\n', size: int = None):
+        """Read a reply up to an expected sequence or size and return it.
+        Mimics Pyserial
+        `read_until <https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.read_until>`_
+        implementation.
+
+        :return: the bytes read including the expected sequence.
+        """
+        if self.t == 'pyserial':
+            return self.io.read_until(expected=expected, size=size)
+        elif self.t == 'usbxpress':
+            data = bytearray()
+            chars_read = 0
+            while True:
+                c = self.io.read(1)
+                data.append(c)
+                chars_read += 1
+                if c.endswith(expected) or (size is not None and chars_read == size):
+                    break
+            return bytes(data)

--- a/src/newscale/new_scale_serial.py
+++ b/src/newscale/new_scale_serial.py
@@ -134,7 +134,7 @@ class NewScaleSerial:
             chars_read = 0
             while True:
                 c = self.io.read(1)
-                data.append(c)
+                data += bytearray(c)
                 chars_read += 1
                 if c.endswith(expected) or (size is not None and chars_read == size):
                     break

--- a/src/newscale/new_scale_serial.py
+++ b/src/newscale/new_scale_serial.py
@@ -1,6 +1,5 @@
 """Utilities for accessing New Scale devices implemented as usbxpress devices."""
 
-from functools import lru_cache
 from newscale.usbxpress import USBXpressDevice
 from serial import Serial
 from serial.tools.list_ports import comports as list_comports
@@ -14,7 +13,6 @@ PID_NEWSCALE_COMPORT = 0xea60
 PID_NEWSCALE_USBX = 0xea61
 
 
-@lru_cache(maxsize=None)
 def get_instances():
     """Factory function to get all New Scale USB Serial hubs, regardless
     of VID/PID. These will be returned in a dict, keyed by serial number (str),


### PR DESCRIPTION
## What's New
* You can now instantiate a `USBInterface` through either
  * the serial number if you know it in advance
  * an existing NewScaleSerial object
  * an existing Serial object
* `get_instances()` is now a standalone function in `new_scale_serial` and returns a dict, keyed by serial number, instead of a list. (You can always spoof the original behavior with `list(get_instances().values())`)
* Put `NewScaleSerial` in its own module
* Updated function signatures in `NewScaleSerial` so that it behaves like a Serial object from pyserial. This preserves the original functionality of the `USBInterface` which could connect with a plain `Serial` object.
* Examples updated.

````python
# Create a connection from a known USB Interface serial number
interface = USBInterface(serial_number="46120")  # OR

# Find all hubs and create a connection on the first one.
from newscale.new_scale_serial import get_instances()

ser = list(get_instances().values())[0]
interface = USBInterface(serial=ser)  # OR

# Create a connection manually by passing in a Serial instance.
from serial import Serial

ser = Serial("COM3", baudrate=250000)
interface = USBInterface(serial=ser)
````

If you init-by-serial-number, that will call `get_instances()` under the hood ~~, but the results are cached so that this only happens once per session in case you're initializing multiple stages this way~~.

## Testing
Examples work on Linux and Windows (after installing the dll.)